### PR TITLE
Improve French support

### DIFF
--- a/Nährwerte.tex
+++ b/Nährwerte.tex
@@ -122,11 +122,11 @@
 \declaretranslation{Dutch}{Salz}{Zout}
 
 %% Dachte immer französisch sei die Sprache der Akzente ...
-\declaretranslation{french}{nahrwerte}{\ERROR}
+\declaretranslation{french}{nahrwerte}{valeurs nutritionnelles}
 \declaretranslation{french}{pro}{par}
 \declaretranslation{french}{Durch.nahrwerte}{Valeurs nutritionnelles moyennes}
 \declaretranslation{french}{Durch.nahr.je}{Valeurs nutritionnelles moyennes par}
-\declaretranslation{french}{energie}{Energie}
+\declaretranslation{french}{energie}{\'{E}nergie}
 \declaretranslation{french}{Fett}{Graisses}
 \declaretranslation{french}{ges.Fettsauren}{acides gras satur\'{e}s}
 \declaretranslation{french}{dav.ges.Fettsauren}{dont acides gras satur\'{e}s}
@@ -164,4 +164,3 @@
 
 
 \end{document}
-

--- a/cooking-units.dtx
+++ b/cooking-units.dtx
@@ -10337,7 +10337,7 @@ and the derived file cooking-units.sty.
 %    \begin{macrocode}
     { pn } [ pinc\'{e}e ] { pinc\'{e}e } [ pinc\'{e}es ] < f >
     { EL } [c.\`{a}.s.] { cuill\`{e}re  \space \`{a} \space  soupe } [ cuill\`{e}res  \space \`{a} \space  soupe ] < f >
-    { TL } [c.\`{a}.c.] { cuill\`{e}re  \space \`{a} \space  caf\'{e} } [ cuill\`{e}re  \space \`{a} \space  caf\'{e} ] < f >
+    { TL } [c.\`{a}.c.] { cuill\`{e}re  \space \`{a} \space  caf\'{e} } [ cuill\`{e}res  \space \`{a} \space  caf\'{e} ] < f >
 %    \end{macrocode}
 %    \begin{macrocode}
     { decimal-mark } { , }

--- a/cooking-units.dtx
+++ b/cooking-units.dtx
@@ -1760,7 +1760,8 @@ and the derived file cooking-units.sty.
 %      {dl} {dL}
 %      {cl} {cL}
 %      {ml} {mL}
-%      {decimal-mark} {.}
+%      {cutext-range-sign} {~\`{a}~}
+%      {decimal-mark} {,}
 %      {one(m)} {un}
 %      {one(f)} {une}
 %      {one(n)} {un}
@@ -6579,6 +6580,7 @@ and the derived file cooking-units.sty.
 \@@_culang_def_base:nnn { name } { decimal-mark }  { . }
 \@@_culang_def_base:nnn { name-pl } { decimal-mark } { \c_@@_no_translation_str }
 \@@_culang_def_for:nnnn { German } { name-pl } { decimal-mark } { , }
+\@@_culang_def_for:nnnn { French } { name-pl } { decimal-mark } { , }
 %    \end{macrocode}
 % Note that the plural versions just exist for completing the set.
 %    \begin{macrocode}
@@ -6599,12 +6601,18 @@ and the derived file cooking-units.sty.
 \@@_culang_def_for:nnnn { German } { name } { one (f) } { eine }
 \@@_culang_def_for:nnnn { German } { name } { one (n) } { ein }
 %    \end{macrocode}
+%    \begin{macrocode}
+\@@_culang_def_for:nnnn { French } { name } { one (m) } { un }
+\@@_culang_def_for:nnnn { French } { name } { one (f) } { une }
+\@@_culang_def_for:nnnn { French } { name } { one (n) } { un }
+%    \end{macrocode}
 %
 %    \begin{macrocode}
 \@@_culang_def_base:nnn { name } { cutext-range-sign } { -- }
 \@@_culang_def_base:nnn { name-pl } { cutext-range-sign } { \c_@@_no_translation_str }
 \@@_culang_def_for:nnnn { German } { name } { cutext-range-sign } { ~bis~ }
 \@@_culang_def_for:nnnn { English } { name } { cutext-range-sign } { ~to~ }
+\@@_culang_def_for:nnnn { French } { name } { cutext-range-sign } { ~\`{a}~ }
 %    \end{macrocode}
 %
 %
@@ -10290,8 +10298,8 @@ and the derived file cooking-units.sty.
   {
     { kg } { kilogramme } [ kilogrammes ]
     { dag } { d\'{e}cagramme } [ d\'{e}cagrammes]
-    { g } { gramme } [ gramme ]
-    { oz } { once } < f >
+    { g } { gramme } [ grammes ]
+    { oz } { once } [ onces ] < f >
     { lb } { livre } [ livres ] < f >
 %    \end{macrocode}
 %    \begin{macrocode}
@@ -10320,19 +10328,19 @@ and the derived file cooking-units.sty.
     { ml } [ mL ] { millilitre } [ millilitres ]
 %    \end{macrocode}
 %    \begin{macrocode}
-    { cal } { calorie } [ calorie ]
-    { kcal } { kilocalorie } [ kilocalories ]
+    { cal } { calorie } [ calories ] < f >
+    { kcal } { kilocalorie } [ kilocalories ] < f >
     { J } { joule } [ joules ]
     { kJ } { kilojoule } [ kilojoules ]
     { eV } { \'{e}lectron-volt } [ \'{e}lectron-volts ]
 %    \end{macrocode}
 %    \begin{macrocode}
-    { pn } { pinc\'{e}e } < f > 
-    { EL } [c.\`{a}.s.] { cuill\`{e}re  \space \`{a} \space  soupe } < f >
-    { TL } [c.\`{a}.c.] { cuill\`{e}re  \space \`{a} \space  caf\'{e} } < f >
+    { pn } [ pinc\'{e}e ] { pinc\'{e}e } [ pinc\'{e}es ] < f >
+    { EL } [c.\`{a}.s.] { cuill\`{e}re  \space \`{a} \space  soupe } [ cuill\`{e}res  \space \`{a} \space  soupe ] < f >
+    { TL } [c.\`{a}.c.] { cuill\`{e}re  \space \`{a} \space  caf\'{e} } [ cuill\`{e}re  \space \`{a} \space  caf\'{e} ] < f >
 %    \end{macrocode}
 %    \begin{macrocode}
-    { decimal-mark } { . }
+    { decimal-mark } { , }
     { one (m) } { un }
     { one (f) } { une }
     { one (n) } { un }


### PR DESCRIPTION
Hi! Thanks for the great package, it's really useful.

I've been using it for a while but noticed a few issues with French units:

* The decimal mark should be a comma instead of a period.
* Some plurals are missing.
* Currently, the plural is used for `\cutext` if the value is not 1, but for French it should only be used if the value is 2 or more.
    For example, *½ cuillère à soupe*, *1½ tasse*, etc.
    I wasn't able to find where this is implemented.

I tried fixing most of these, but I'm not completely sure how to build and test.
Running the tests using `l3build check`, it seems to get stuck indefinitely on step 4:

```
Running checks on
  conversions01 (1/10)
  conversions02 (2/10)
  conversions03 (3/10)
  cusetup_parse-number (4/10)
```

What's the usual workflow for building and testing this package?